### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.DS_Store
+.Rapp.history


### PR DESCRIPTION
The repo doesn't need to include the history from the R app (which is
empty currently anyway. It also shouldn't include .DS_Store, a hidden
file which OS X will add to a directory.

I removed the empty .Rapp.history file as well.
